### PR TITLE
Check for skipped issues before checking status

### DIFF
--- a/dsc2jira.py
+++ b/dsc2jira.py
@@ -136,6 +136,10 @@ def main(conf, start_date):
                     updated_items_cnt = updated_items_cnt+1
                 else:
                     issue_key = db_entry["jira"]
+                    if issue_key =="skip":
+                        logging.warning("Issue entry was skipped for topic {}. ".format(forum_topic["id"]))
+                        logging.warning("Please see https://github.com/canonical/Discourse2Jira/blob/main/README.md#initial-setup")
+                        continue
                     issue_to_check = jira.issue(issue_key, expand='changelog')
                     try: 
                         if issue_to_check.fields.status.name == "Rejected" or issue_to_check.fields.status.name == "Done":


### PR DESCRIPTION
If an entry in the forum_db contains skipped issues, this script will try to check JIRA for issues with id "skip" (instead of a valid JIRA issue ID)

This consequently fails with: 
```
DEBUG:urllib3.connectionpool:https://warthogs.atlassian.net:443 "GET /rest/api/2/issue/skip?expand=changelog HTTP/1.1" 404 None
Traceback (most recent call last):
  File "/home/ubuntu-security/git-pulls/Discourse2Jira/dsc2jira.py", line 225, in <module>
    main(conf, start_date)
  File "/home/ubuntu-security/git-pulls/Discourse2Jira/dsc2jira.py", line 141, in main
    issue_to_check = jira.issue(issue_key, expand='changelog')
  File "/usr/lib/python3/dist-packages/jira/client.py", line 1071, in issue
    issue.find(id, params=params)
  File "/usr/lib/python3/dist-packages/jira/resources.py", line 201, in find
    self._load(url, params=params)
  File "/usr/lib/python3/dist-packages/jira/resources.py", line 316, in _load
    r = self._session.get(url, headers=headers, params=params)
  File "/usr/lib/python3/dist-packages/jira/resilientsession.py", line 151, in get
    return self.__verb('GET', url, **kwargs)
  File "/usr/lib/python3/dist-packages/jira/resilientsession.py", line 147, in __verb
    raise_on_error(response, verb=verb, **kwargs)
  File "/usr/lib/python3/dist-packages/jira/resilientsession.py", line 56, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 404 url: https://warthogs.atlassian.net/rest/api/2/issue/skip?expand=changelog
    text: Issue does not exist or you do not have permission to see it.
    
    response headers = {'Date': 'Tue, 16 Jan 2024 17:31:51 GMT', 'Content-Type': 'application/json;charset=UTF-8', 'Server': 'AtlassianEdge', 'Timing-Allow-Origin': '*', 'X-Arequestid': '865c3556e6e30903f6b12fe06b36cd8d', 'X-Aaccountid': '62f1f2f65111209f4fe030ec', 'Cache-Control': 'no-cache, no-store, no-transform', 'Server-Timing': 'filter-workcontext;dur=42, filter-frontend-router;dur=21, mcache-client;dur=6, filter-request-papi;dur=43', 'Content-Encoding': 'gzip', 'X-Content-Type-Options': 'nosniff', 'X-Xss-Protection': '1; mode=block', 'Atl-Traceid': '00f7518541df4fd4aa4dab1afdb34f47', 'Report-To': '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group": "endpoint-1", "include_subdomains": true, "max_age": 600}', 'Nel': '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to": "endpoint-1"}', 'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload', 'Transfer-Encoding': 'chunked'}
    response text = {"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}
```

This can happen during db initialization.

This PR tries to detect this issue and and also recommends reading the [initial-setup](https://github.com/canonical/Discourse2Jira/blob/main/README.md#initial-setup) documentation for further instructions 