### PR TITLE
Adding exception handling to issue retrieval

### DIFF
--- a/dsc2jira.py
+++ b/dsc2jira.py
@@ -67,7 +67,8 @@ def import_json_db(filename):
     with open(filename, "r") as json_file:
         try:
             my_list = json.load(json_file)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            logging.error(f"JSONDecodeError while importing db: {e}")
             return []
     return my_list
 
@@ -201,8 +202,10 @@ if __name__ == "__main__":
     else:
         logging.error("database file not does not exist or is not writable: {}".format(args.db_file))
         sys.exit(-1)
-
-    start_date = parse_date_duration(args.duration)
+    try:
+        start_date = parse_date_duration(args.duration)
+    except ValueError as e:
+        logging.error(f"Unable to resolve start_date: {e}")
     logging.debug(f"{start_date}")
     logging.debug("Using {} time period".format(args.duration))
 

--- a/dsc2jira.py
+++ b/dsc2jira.py
@@ -204,9 +204,9 @@ if __name__ == "__main__":
         sys.exit(-1)
     try:
         start_date = parse_date_duration(args.duration)
-        sys.exit(-1)
     except ValueError as e:
         logging.error(f"Unable to resolve start_date: {e}")
+        sys.exit(-1)
     logging.debug(f"{start_date}")
     logging.debug("Using {} time period".format(args.duration))
 

--- a/dsc2jira.py
+++ b/dsc2jira.py
@@ -140,8 +140,8 @@ def main(conf, start_date):
                         logging.warning("Issue entry was skipped for topic {}. ".format(forum_topic["id"]))
                         logging.warning("Please see https://github.com/canonical/Discourse2Jira/blob/main/README.md#initial-setup")
                         continue
-                    issue_to_check = jira.issue(issue_key, expand='changelog')
                     try: 
+                        issue_to_check = jira.issue(issue_key, expand='changelog')
                         if issue_to_check.fields.status.name == "Rejected" or issue_to_check.fields.status.name == "Done":
                             changelog = issue_to_check.changelog
                             latest_change = changelog.histories[0]  # Assuming the latest change is at the beginning of the histories list
@@ -153,7 +153,7 @@ def main(conf, start_date):
                             if latest_change_datetime < seven_days_ago:
                                 jira.transition_issue(issue_to_check, "In Progress")
                     except:
-                        logging.debug("error reading status of jira ticket: {}, {}".format(db_entry["slug"], db_entry["jira"]))
+                        logging.error("error reading status of jira ticket: {}, {}".format(db_entry["slug"], db_entry["jira"]))
                     # this is the usual case, just log it
                     logging.debug("item already in database with jira ticket: {}, {}".format(db_entry["slug"], db_entry["jira"]))
                 break

--- a/dsc2jira.py
+++ b/dsc2jira.py
@@ -204,6 +204,7 @@ if __name__ == "__main__":
         sys.exit(-1)
     try:
         start_date = parse_date_duration(args.duration)
+        sys.exit(-1)
     except ValueError as e:
         logging.error(f"Unable to resolve start_date: {e}")
     logging.debug(f"{start_date}")

--- a/dsc2jira.py
+++ b/dsc2jira.py
@@ -32,11 +32,11 @@ class Configuration:
     
 def fetch_forum_topics(conf, start):
 
-    logging.info("Downloading 'store-requests' discourse forum topics since {}".format(start))
+    logging.debug("Downloading 'store-requests' discourse forum topics since {}".format(start))
     category = dsctriage.dscfinder.get_category_by_name(conf.forum_category, conf.forum_url)
     dsctriage.dscfinder.add_topics_to_category(category, start, conf.forum_url)
 
-    logging.info("{} topics downloaded".format(category))
+    logging.debug("{} topics downloaded".format(category))
 
     return category
 
@@ -84,10 +84,10 @@ def create_issue(config, project, summary, desc, issuetype, component):
     issue = 0
     if not config.dryrun and not config.initdb:
         issue = jira.create_issue(fields=issue_dict)
-        logging.info("creating ticket: {}, {}".format(issue, issue_dict["summary"]))
+        logging.debug("creating ticket: {}, {}".format(issue, issue_dict["summary"]))
         return issue
     else:
-        logging.info("[DRY RUN] creating ticket: {}, {}".format(issue, issue_dict["summary"]))
+        logging.debug("[DRY RUN] creating ticket: {}, {}".format(issue, issue_dict["summary"]))
         return "skip"
     
 
@@ -167,9 +167,9 @@ def main(conf, start_date):
         database_list.append(i)
 
     if not conf.dryrun and not conf.initdb:
-        logging.info("Created {} Jira entries".format(len(new_list) + updated_items_cnt))
+        logging.debug("Created {} Jira entries".format(len(new_list) + updated_items_cnt))
     else:
-        logging.info("[DRY RUN] Created {} Jira entries".format(len(new_list) + updated_items_cnt))
+        logging.debug("[DRY RUN] Created {} Jira entries".format(len(new_list) + updated_items_cnt))
 
     #save the database
     if not conf.dryrun:
@@ -203,7 +203,7 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     start_date = parse_date_duration(args.duration)
-    logging.info(f"{start_date}")
+    logging.debug(f"{start_date}")
     logging.debug("Using {} time period".format(args.duration))
 
 


### PR DESCRIPTION
If a JIRA issue which is present in the DB is not available in the JIRA server anymore, the app is crashing:

```Traceback (most recent call last):
  File "/home/ubuntu-security/git-pulls/Discourse2Jira/dsc2jira.py", line 226, in <module>
    main(conf, start_date)
  File "/home/ubuntu-security/git-pulls/Discourse2Jira/dsc2jira.py", line 143, in main
    issue_to_check = jira.issue(issue_key, expand='changelog')
  File "/usr/lib/python3/dist-packages/jira/client.py", line 1071, in issue
    issue.find(id, params=params)
  File "/usr/lib/python3/dist-packages/jira/resources.py", line 201, in find
    self._load(url, params=params)
  File "/usr/lib/python3/dist-packages/jira/resources.py", line 316, in _load
    r = self._session.get(url, headers=headers, params=params)
  File "/usr/lib/python3/dist-packages/jira/resilientsession.py", line 151, in get
    return self.__verb('GET', url, **kwargs)
  File "/usr/lib/python3/dist-packages/jira/resilientsession.py", line 147, in __verb
    raise_on_error(response, verb=verb, **kwargs)
  File "/usr/lib/python3/dist-packages/jira/resilientsession.py", line 56, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 404 url: https://warthogs.atlassian.net/rest/api/2/issue/SEC-2660?expand=changelog
    text: Issue does not exist or you do not have permission to see it.
    
    response headers = {'Date': 'Wed, 24 Jan 2024 12:45:19 GMT', 'Content-Type': 'application/json;charset=UTF-8', 'Server': 'AtlassianEdge', 'Timing-Allow-Origin': '*', 'X-Arequestid': '37aa6ac1eca6420e49f6e3bf94f1ca18', 'X-Aaccountid': '62f1f2f65111209f4fe030ec', 'Cache-Control': 'no-cache, no-store, no-transform', 'Server-Timing': 'filter-workcontext;dur=77, filter-frontend-router;dur=80, mcache-client;dur=6, filter-request-papi;dur=77, sql;dur=3', 'Content-Encoding': 'gzip', 'X-Content-Type-Options': 'nosniff', 'X-Xss-Protection': '1; mode=block', 'Atl-Traceid': '4dfb2b649d52485b9225251270a43c99', 'Report-To': '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group": "endpoint-1", "include_subdomains": true, "max_age": 600}', 'Nel': '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to": "endpoint-1"}', 'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload', 'Transfer-Encoding': 'chunked'}
    response text = {"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}
```

In this PR I am proposing including the issue querying to the exception handling as well to prevent the app to crash